### PR TITLE
fix(dev-norms.md): add space after heading mark

### DIFF
--- a/dev-norms.md
+++ b/dev-norms.md
@@ -1,4 +1,4 @@
-#Norms
+# Norms
 Developer norms are a necessary way to set some ground rules, so your code base can retain some consistency, remain maintainable over the next days, months and years and all developers are on the same page.
 
 Here's a starter list of developer norms:


### PR DESCRIPTION
Adds a space between the heading mark of `#` and the content of the header ("Norms"), in order to make the header visually display as a header.